### PR TITLE
Fix jellyfin_active_streams_count_direct/jellyfin_active_streams_coun…

### DIFF
--- a/jellyfin_exporter.py
+++ b/jellyfin_exporter.py
@@ -94,8 +94,8 @@ class JellyfinCollector(object):
                     streams_count += 1
 
                     now_playing = user['NowPlayingItem']
-                    if 'TranscodingInfo' in now_playing:
-                        tc = now_playing['TranscodingInfo']
+                    if 'TranscodingInfo' in user:
+                        tc = user['TranscodingInfo']
                         if tc['IsVideoDirect'] == True:
                             streams_direct_count += 1
                         else:


### PR DESCRIPTION
Hello,

Running latest Jellyfin 10.10.3 the `/Sessions` data is different than what's expected in the code, causing transcode streams to be counted as `jellyfin_active_streams_count_direct` instead of `jellyfin_active_streams_count_transcode`.

That fixes it.